### PR TITLE
feat: set up SpringDoc (OpenAPI/Swagger) for core-api

### DIFF
--- a/core-api/build.gradle.kts
+++ b/core-api/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${property("openApiVersion")}")
 
     testImplementation("com.tngtech.archunit:archunit-junit5:${property("archunitVersion")}")
 }

--- a/core-api/src/main/kotlin/com/tj/boilerplate/coreapi/confirguration/OpenApiConfiguration.kt
+++ b/core-api/src/main/kotlin/com/tj/boilerplate/coreapi/confirguration/OpenApiConfiguration.kt
@@ -1,0 +1,33 @@
+package com.tj.boilerplate.coreapi.confirguration
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenApiConfiguration {
+    @Bean
+    fun openAPI(): OpenAPI =
+        OpenAPI()
+            .info(
+                Info()
+                    .title("core-api")
+                    .description("core-api OpenAPI documentation")
+                    .version("v1"),
+            ).components(
+                Components().addSecuritySchemes(
+                    BEARER_AUTH,
+                    SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT"),
+                ),
+            )
+
+    companion object {
+        const val BEARER_AUTH = "bearerAuth"
+    }
+}

--- a/core-api/src/main/kotlin/com/tj/boilerplate/coreapi/controller/system/SystemController.kt
+++ b/core-api/src/main/kotlin/com/tj/boilerplate/coreapi/controller/system/SystemController.kt
@@ -1,10 +1,14 @@
 package com.tj.boilerplate.coreapi.controller.system
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "시스템 API", description = "헬스 체크 등 시스템 엔드포인트")
 @RestController
 class SystemController {
+    @Operation(summary = "헬스 체크", description = "서버 상태를 확인한다")
     @GetMapping("/health")
     fun healthCheck(): String = "pong"
 }

--- a/core-api/src/main/resources/application.yml
+++ b/core-api/src/main/resources/application.yml
@@ -6,3 +6,16 @@ spring:
     import:
       - domain.yml
       - lock.yml
+
+springdoc:
+  swagger-ui:
+    enabled: true
+
+---
+spring.config.activate.on-profile: live
+
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ projectGroup=com.tj.boilerplate
 kotlinVersion=2.1.21
 javaVersion=21
 ktlintVersion=14.2.0
-openApiVersion=2.1.0
+openApiVersion=2.8.17
 logbackVersion=1.4.7
 
 # Spring dependency versions


### PR DESCRIPTION
## Summary
`kotlin-conventions/rules/api-docs.md` 규칙에 맞춰 core-api에 SpringDoc(OpenAPI/Swagger)을 셋업합니다.

- **의존성**: `springdoc-openapi-starter-webmvc-ui` 추가, `openApiVersion` 2.1.0 → **2.8.17** (Spring Boot 3.5 호환)
- **`OpenApiConfiguration`**: API info + `bearerAuth`(HTTP bearer / JWT) 보안 스킴을 **1회 정의**
- **`SystemController`**: `@Tag` + `@Operation(summary = ...)` 부여 (공개 엔드포인트 문서화)
- **application.yml**: Swagger UI 기본 활성, **prod(`live`) 프로파일에선 `api-docs`·`swagger-ui` 모두 비활성** (운영 노출 통제)

## 컨벤션 매핑
| 규칙(api-docs.md) | 적용 |
|---|---|
| `@Tag`/`@Operation(summary)` 필수 | SystemController ✅ |
| 보안 스킴 `OpenAPIConfig`에서 1회 | OpenApiConfiguration `bearerAuth` ✅ |
| prod Swagger UI 프로파일 통제 | `live`에서 비활성 ✅ |

## 참고
- 현재는 스켈레톤이라 `ApiResponse<T>` 래퍼·도메인 컨트롤러가 아직 없어 문서 대상은 `/health`뿐입니다. 컨트롤러가 추가되면 같은 패턴으로 `@Tag`/`@Operation`/`@SecurityRequirement`를 답니다.
- config 패키지명이 기존 `coreapi.confirguration`(오타) 이라 일관성을 위해 그대로 두었습니다 — 정정(`configuration`)은 별도 정리 PR 권장.

## Test
- `./gradlew clean build` (컴파일 + 전 모듈 test + ArchUnit) → BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)